### PR TITLE
Reforma 1

### DIFF
--- a/Estatutos CAi.tex
+++ b/Estatutos CAi.tex
@@ -635,8 +635,8 @@
 				\item Para alumnos cursando un major y pertenecientes al menos a la tercera generación, cada estudiante tendrá derecho a votar por un candidato de su respectivo major y por dos candidatos de su respectiva generación. En ningún caso podrá acumular estos dos votos en un mismo candidato.
 				\item Para alumnos cursando una especialidad, cada alumno tendrá derecho a votar por un candidato de su departamento, especialidad o centro, además de poder votar por un candidato del Departamento de Ingeniería Industrial en caso que este cursando una mención asociada a ese departamento. También deberá votar por dos candidatos de su respectiva generación. En ningún caso podrá acumular estos dos votos en un mismo candidato.
 				\item Para los alumnos de la quinta generación que se encuentren cursando su último semestre de major e iniciando su especialidad, cada alumno tendrá la opción de decidir si votar por un delegado de su major o de su departamento, especialidad o centro. En caso de elegir votar por especialidad, y en caso de que el alumno este cursando una especialidad Industrial, también podrá votar por un candidato del Departamento de Ingeniería Industrial.
-				\item Para alumnos cursando algún programa de Postgrado, cada alumno tendrá derecho a votar por un candidato de su departamento, especialidad o centro. También deberá votar por dos candidatos a delegado generacional por postgrado. En ningún caso podrá acumular estos dos votos en un mismo candidato.
-				\item Los alumnos que cursen de forma simultánea Pregrado y Postgrado en la Escuela de Ingeniería podrán sufragar en una sola oportunidad. Cada alumno tendrá derecho a votar por un candidato de su departamento, especialidad o centro, además de poder votar por un candidato del Departamento de Ingeniería Industrial en caso que este cursando una mención asociada a ese departamento. También deberá votar por dos candidatos a delegado generacional, los cuales podrá repartir entre los candidatos de su respectiva generación o de Postgrado. En ningún caso podrá acumular estos dos votos en un mismo candidato.
+				\item Para alumnos cursando algún programa de Postgrado, cada alumno tendrá derecho a votar por un candidato de su área de postgrado, especialidad o centro.
+				\item Los alumnos que cursen de forma simultánea Pregrado y Postgrado en la Escuela de Ingeniería podrán sufragar en una sola oportunidad. Cada alumno tendrá derecho a votar por un candidato de su departamento, especialidad o centro, además de poder votar por un candidato del Departamento de Ingeniería Industrial en caso que este cursando una mención asociada a ese departamento. También deberá votar por dos candidatos a delegado generacional en Pregrado. En ningún caso podrá acumular estos dos votos en un mismo candidato.
 				\item Para alumnos de College de Licenciatura en Ciencias Naturales que cumplan los requisitos del artículo \ref{porcentajeMinimo}, cada alumno tendrá derecho a votar por un candidato a Representante de College.
 				\item Durante la cuarta semana a partir del inicio del primer periodo académico para alumnos antiguos se abrirán las inscripciones para los postulantes. La apertura de inscripciones deberá ser avisada con una semana de anticipación. No existe restricción con respecto al número máximo de postulantes, siempre que todos cumplan con los requisitos estipulados en el presente estatuto. Las fechas podrán ser adelantadas o retrasadas con un margen máximo de dos semanas, previa aprobación del Consejo respectivo bajo quórum calificado.
 				\item Se cerrará el proceso de inscripciones cinco días hábiles después de haber sido abierto. Durante estos días, los candidatos tendrán la obligación de entregar al CAi los siguientes documentos:
@@ -665,7 +665,6 @@
 				\item Para los Delegados Generacionales:
 					\begin{enumerate}
 						\item Alumnos de pregrado: pertenecer a la generación que representaría y estar cursando a lo menos 30 créditos del currículum. Además, presentar en la oficina del CAi 50 firmas que validen la candidatura.
-						\item Alumnos de postgrado: estar trabajando bajo tutela de un profesor en una tesis de Magister o Doctorado.
 					\end{enumerate}
 				\item Para los Delegados Académicos; en el caso de major, estar inscrito en el major al cual se postula como representante y estar cursando al menos la tercera generación; en el caso de los departamentos o especialidades sin departamento, estar cursando la especialidad o mención a la cual se postula como representante y contar con el grado de licenciado o estar a 30 créditos o menos de cumplirlo. Además el postulante, en el caso de ser alumno de pregrado, debe estar cursando a lo menos 30 créditos del currículum, y llevar realizados al menos 40 créditos o estar cursando al menos un ramo de la especialidad, major o mención que declara cursar. En el caso de los alumnos de postgrado, deben estar trabajando bajo tutela de un profesor en una tesis del departamento o especialidad a la cual postula.
 			\end{enumerate}
@@ -783,6 +782,14 @@
 				Cada Consejo puede ser citado en forma extraordinaria por el Comité Ejecutivo, por un tercio de los Delegados o quién lo presida, debiendo ser notificado a todos los miembros del consejo vía correo electrónico con al menos 24 hrs de anticipación.
 			\end{art}
 
+			\begin{art}\label{sesionesPostgrado}
+				Los delegados académicos de Postgrado votarán en las sesiones del Consejo Académico de Postgrado, llevándose los respectivos resultados al Consejo Académico de Pregrado a través del Consejero correspondiente.
+			\end{art}
+
+			\begin{art}\label{votosPostgrado}
+				Vinculado al inciso anterior, los delegados académicos de Postgrado quedan exentos de la pérdida del derecho a voto por ausencia en el Consejo Académico de Pregrado.
+			\end{art}
+
 			\begin{art}\label{facultadesPrecide}
 				La facultad de quién presida la sesión comprende:
 				\begin{enumerate}
@@ -854,8 +861,6 @@
 						\begin{itemize}
 							\item Cada Delegado de generación tendrá un voto.
 							\item El Comité Ejecutivo tendrá tres votos, correspondientes al Presidente y Vice-presidentes.
-							\item El delegado de postgrado que se encuentre representado en dicha
-							oportunidad tendrá un voto, con excepción de aquellas votaciones que deban ser llevadas al Consejo de Federación y no tengan relación directa con los programas de postgrado.
 							\item El Consejero Académico tendrá un voto.
 							\item El Consejero de Postgrado tendrá un voto.
 						\end{itemize}
@@ -976,7 +981,7 @@
 					\item Cualquier miembro del Comité Ejecutivo, el cual será electo de la forma en que este lo estime conveniente. Dicho miembro presidirá el Tribunal.
 					\item Dos delegados de cada  Consejo escogidos por los delegados del respectivo Consejo en una sola votación. En el caso de presentarse un número par de listas se elegirán tres delegados del Consejo Generacional con el objetivo de lograr un número impar de integrantes del TRICEL.
 					\item Los apoderados de las listas postulantes al Comité Ejecutivo si corresponde. Ellos deberán ser alumnos regulares. El cargo de miembro del TRICEL es incompatible con el de candidato a una elección para la cual se constituye el Tribunal.
-					\item Para la elección de Comité Ejecutivo y Consejeros, un profesor de la Escuela, o en su defecto, uno de los representantes de postgrado elegido entre el Consejero de Postgrado, el Jefe de Investigación y los delegados de postgrado del Comité Generacional.
+					\item Para la elección de Comité Ejecutivo y Consejeros, un profesor de la Escuela, o en su defecto, uno de los representantes de postgrado elegido entre el Consejero de Postgrado, el Jefe de Investigación y Postgrado y los delegados de postgrado del Comité Académico.
 				\end{enumerate}
 			\end{art}
 


### PR DESCRIPTION
Actualmente los estatutos siguen estipulando que haya un delegado de generación de postgrado, pero esto se contradice con el artículo que se cambió el año pasado para que solo tuviesen carácter académico, por lo que ahora se quiere eliminar las referencias incorrectas.