### PR TITLE
Se elimina mineria

### DIFF
--- a/Estatutos CAi.tex
+++ b/Estatutos CAi.tex
@@ -163,7 +163,6 @@
 						\item Eléctrica
 						\item Ciencias de la Computación
 						\item Química y Bioprocesos e Instituto de Ingeniería Biológica y Médica)
-						\item Minería 
 					\end{enumerate}
 
 				\item \textsc{Consejo Generacional} Es la máxima instancia de representación. Formado por el Comité Generacional, el Comité Ejecutivo, el Consejero Académico y el Consejero de Postgrado. Es presidido por el Presidente del CAi.


### PR DESCRIPTION
El disminuir la cantidad de áreas de permitirá focalizar mejor los esfuerzos de las áreas actualmente existentes en los delegados. Esto se debe a que actualmente la participación de postgrado es reducida en el consejo debido a que se tiene un enfoque más apuntado hacia Pregrado en el consejo académico. En este sentido, abarcar más temas por delegado permitirá que aquellos delegados de postgrado puedan tener un mayor aporte en el consejo debido a la mezcla de áreas que se complementan y los temas que puedan surgir a partir de las áreas.