### PR TITLE
R6: Voto College

### DIFF
--- a/Estatutos CAi.tex
+++ b/Estatutos CAi.tex
@@ -456,7 +456,7 @@
 	\section{Elecciones, requisitos y sanciones}\label{elecciones}
 
 		\begin{art}\label{porcentajeMinimo}
-			Tendrán derecho a votar todos los alumnos regulares de Pregrado de la Escuela de Ingeniería, así como los alumnos de Magíster en Ingeniería, Magíster en Ciencias de la Ingeniería y Doctorado, salvo cuando este estatuto específicamente indique algo distinto. Tratándose de la elección del Representante de College, tendrán derecho a voto los alumnos de College de Licenciatura en Ciencias Naturales que hayan cursado Desafíos de la Ingeniería, al menos 30 créditos de la malla de Ingeniería, y que al menos tengan un ramo inscrito de la malla de Ingeniería al momento de votar.
+			Tendrán derecho a votar todos los alumnos regulares de Pregrado de la Escuela de Ingeniería, así como los alumnos de Magíster en Ingeniería, Magíster en Ciencias de la Ingeniería y Doctorado, salvo cuando este estatuto específicamente indique algo distinto. Tratándose de la elección del Comité Ejecutivo y Consejero Académico, tendrán derecho a voto los alumnos de College de Licenciatura en Ciencias Naturales que tengan inscrito el major de la Escuela de Ingeniería a comienzos del segundo semestre.
 
 			Todas las elecciones y plebiscitos son válidos solo si en ellos vota al menos el 35\% de los alumnos con derecho a voto, salvo que en este estatuto se establezca explícitamente otra cosa. En caso de no cumplirse este quórum le corresponder a decidir al Consejo que haya llamado a plebiscitar.
 		\end{art}
@@ -538,6 +538,8 @@
 				\item \label{periodo}A lo más dos días hábiles después de la asamblea de presentación de las listas, se iniciará el período de votación, que se prolongará por dos días hábiles.
 				
 				\item \label{votantes}Los alumnos que se encuentren cursando Pregrado en la Escuela de Ingeniería tendrán derecho a votar por Comité Ejecutivo y por Consejero Académico. Aquellos que cursen Postgrado en la misma tenderán derecho a votar por Comité Ejecutivo y por Consejero de Postgrado.
+
+				\item \label{votantesCollege} Los estudiantes que se encuentren cursando College de Licenciatura en Ciencias Naturales y cumplan con lo dispuesto en el artículo 21, tendrán derecho a votar por Comité Ejecutivo y por Consejero Académico de Pregrado. Para evitar la sobrerrepresentación de aquellos estudiantes que sean admisibles para votar, se deberán inscribir de forma previa, con dos o más semanas de anticipación, para votar en Ingeniería y no poder votar por las elecciones del Centro de Estudiantes de College, o al revés (teniendo, por defecto, en caso de que no se inscriban, su voto por la facultad de College).
 				
 				\item Los alumnos que cursen de forma simultánea Pregrado y Postgrado en la Escuela de Ingeniería podrán sufragar en una sola oportunidad, votando de forma simultánea al Comité Ejecutivo, Consejero Académico y Consejero de Postgrado.
 				


### PR DESCRIPTION
Actualmente los alumnos de College que están en vías de cambiarse a Ingeniería no pueden votar por los miembros del Comité Ejecutivo y Consejero Académico (lista CAi + consejero), siendo que varias veces ocurre que hay estudiantes de esta facultad que próximamente serán parte de la Escuela de Ingeniería, por lo que sí serán representados por aquellos representantes que sean electos en las elecciones. En este sentido, se quiere dar la opción de que estos estudiantes tengan la posibilidad de poder elegir a aquellos que los representarán en sus próximos semestres.

Para evitar la sobrerrepresentación de estos estudiantes, lo que se hará es agregar la restricción de aquellos estudiantes que sean admisibles para votar por ingeniería se deban inscribir de forma previa para votar en ingeniería y no poder votar por las elecciones de College, o al revés (teniendo, por defecto, en caso de que no se inscriban, su voto por la facultad de College).