### PR TITLE
Se permiten cambios de ortogafia

### DIFF
--- a/Estatutos CAi.tex
+++ b/Estatutos CAi.tex
@@ -1050,7 +1050,8 @@
 		\begin{art}\label{normaReforma}
 			Cualquier posible reforma al presente Cuerpo de Estatutos deberá seguir las siguientes normas:
 			\begin{enumerate}
-				\item Deberá ser tratada, discutida y votada ampliamente en el Consejo Académico y el Consejo Generacional.
+				\item Deberá ser tratada, discutida y votada ampliamente en el Consejo Académico y el Consejo Generacional, a excepción de correcciones ortográficas acentuales o literal que no alteren la manera en que operan los estatutos, su interpretación e idea fundamental. Estas últimas deberán ser presentadas y explicadas en ambos consejos. En caso de que se presentase alguna objeción por uno o más miembros de cualquiera de los consejos se, deberá votar el cambio como se haría con cualquier otra reforma.
+
 				\item  Podrá ser presentada al Consejo Académico y al Consejo Generacional solo a través de miembros de él.
 
 				\item  En caso de ser los Estatutos principales, requerirá acuerdo de a lo menos dos tercios del total de los votos posibles del Consejo Académico y también del Consejo Generacional, independiente de ausencias o presencias. Estas reformas entrarán en vigencia a partir del primer día hábil del semestre académico siguiente a la publicación de ésta.


### PR DESCRIPTION
Actualmente, para cualquier tipo de cambio en los estatutos, se requiere aprobación de ambos consejos. Esto impide que se puedan realizar cambios que corrijan la ortografía (no redacción, puntos o comas) de estos en los casos en que está errada. En este sentido, se quiere agilizar el proceso y se propone que los cambios ortográficos (inserción de puntos finales al final de un párrafo, tildes, o cambio de letras) que no alteren la manera en que operan los estatutos o su interpretación. Luego de la realización de estos cambios se deberá presentar a ambos consejos el cambio realizado.

En caso de que alguno de los miembros de cualquiera de los dos consejos no esté de acuerdo con el cambio realizado, entonces se deberá somete a votación el cambio como se haría con cualquier otro cambio de estatuto.