### PR TITLE
Historial y versionamiento

### DIFF
--- a/Estatutos CAi.tex
+++ b/Estatutos CAi.tex
@@ -1044,6 +1044,10 @@
 	\section{Reformas}\label{reformas}
 
 		\begin{art}
+			Se deberá mantener un historial de cambios y propuestas, tanto aprobadas como rechazadas, de los estatutos en la plataforma GitHub (https://github.com/centro-de-alumnos-de-ingenieria/Estatutos). La administración de este historial será responsabilidad del Secretario General, el cual deberá usar el sistema de “pull requests” y “branches” para mantener de manera ordenada los cambios realizados y propuestos, detallándolos de la mejor manera posible.
+		\end{art}
+
+		\begin{art}
 			Estos estatutos son de carácter rígido e inapelable, es decir, no se aceptan excepciones, solo reformas.
 		\end{art}
 


### PR DESCRIPTION
Actualmente no existe un historial de cambios realizados a los estatutos a través del tiempo. Lo que se propone es implementar uno mediante la plataforma GitHub. Esta plataforma permite mantener un historial no solo de los cambios realizados, sino que también de aquellos que son rechazados. Es decir, esto permitiría tener un historial de cambios realizados, rechazados y las justificaciones pertinentes (a manera de descripción de cambio) de por qué fue rechazado o aprobado y con cuál porcentaje.

Adicionalmente, se pueden proponer cambios de estatutos mediante las issues que podrían ser abiertas a los alumnos de la Escuela.