### PR TITLE
Poder bajar paro a plebiscitos

### DIFF
--- a/Estatutos CAi.tex
+++ b/Estatutos CAi.tex
@@ -892,8 +892,22 @@
 				Las votaciones que requieran quórum calificado, serán aprobadas por dos tercios de los votos presentes.
 			\end{art}
 
-			\begin{art}\label{votacionMovilizacionParo}
-				Las votaciones para decidir la participación en paros o actividades que alteren el funcionamiento normal de la Escuela deberán ser tomadas en el Consejo Generacional y requerirán quórum calificado de la forma en que se especifica en este Estatuto. En caso de decidir la participación en movilizaciones estudiantiles, estas requerirán mayoría simple. En ambos casos, para el cálculo de este quórum no se contabilizarán a los delegados de postgrado si ellos no participan en la votación.  
+			\begin{art}\label{votacionParo}
+				Las votaciones para decidir la participación en paros o actividades que alteren el funcionamiento normal de la Escuela deberán ser tomadas en el Consejo Generacional o mediante un plebiscito válido. El funcionamiento será el siguiente:
+				\begin{enumerate}
+					\item Para aprobar una paralización o una actividad que altere el funcionamiento normal de la escuela en el Consejo Generacional, se requerirá de quórum calificado de la forma que se especifica en el artículo 58.
+					\item Para plebiscitar una actividad que altere el funcionamiento normal de la escuela se requerirá mayoría simple del consejo generacional.
+					\item Para que la actividad sea aprobada mediante un plebiscito, este requerirá de mayoría simple.
+				\end{enumerate}
+			\end{art}
+
+			\begin{art}\label{votacionMovilizacion}
+				Las votaciones para decidir la adherencia o no adherencia de movilizaciones estudiantiles deberán ser tomadas en el Consejo Generacional o mediante un plebiscito válido. El funcionamiento será el siguiente:
+				\begin{enumerate}
+					\item Para aprobar una movilización en el consejo generacional, se requerirá de mayoría simple.
+					\item Para plebiscitar una movilización se requerirá mayoría simple.
+					\item Para que la movilización sea aprobada mediante un plebiscito, este requerirá de mayoría simple.
+				\end{enumerate}
 			\end{art}
 
 			\begin{art}\label{votacionExterna}


### PR DESCRIPTION
Actualmente la decisión de la adherencia a paros necesariamente debe ser tomadas en el consejo generacional. En este sentido, se quiere dar la opción de que se pueda bajar a plebiscito una marcha y paralización y que el resultado no deba ser ratificado.

Para esto, se pretende establecer dos artículos que especifiquen de manera clara el procedimiento en cada caso.