### PR TITLE
Ausencias

### DIFF
--- a/Estatutos CAi.tex
+++ b/Estatutos CAi.tex
@@ -731,7 +731,7 @@
 			\end{enumerate}
 
 			El tiempo mínimo que debe estar un miembro del Consejo durante una sesión para que su asistencia sea considerada es de 30 minutos. La asistencia de los miembros del Consejo debe ser publicada en la página web del CAi.\\
-			En caso de que las restricciones A o B del presente artículo sean violadas, el Delegado será sancionado con la pérdida inmediata del derecho a voz y voto en el Consejo al que pertenece, si bien podrá seguir representando a los alumnos frente a los profesores de su generación, major, departamento o especialidad, según sea el caso. En el caso del Comité Ejecutivo, este perderá el derecho a voz y voto por el resto de su período.\\
+			En caso de que las restricciones A o B del presente artículo sean violadas, el Delegado será sancionado con la pérdida inmediata del derecho a voz y voto en ambas instancias del Consejo al que pertenece (sesiones ordinarias y extraordinarias), si bien podrá seguir representando a los alumnos frente a los profesores de su generación, major, departamento o especialidad, según sea el caso. En el caso del Comité Ejecutivo, este perderá el derecho a voz y voto por el resto de su período.\\
 			Tratándose de los delegados generacionales de la primera y segunda generación, se considerará como ausencia al Consejo Académico el hecho de que ninguno de los tres esté resente. En el caso de no cumplir con las restricciones A o B del presente artículo, se considerará que pierden su derecho a voz y voto por el resto de su período en dicho Consejo.
 		\end{art}
 

--- a/Estatutos CAi.tex
+++ b/Estatutos CAi.tex
@@ -725,6 +725,9 @@
 				\item \label{ausencias_B} Sesiones Extraordinarias: un máximo de tres ausencias cada diez sesiones de consejos extraordinarios, siempre y cuando sean citados con al menos 36 horas de anticipación. La cantidad de ausencias se extiende en tres más para cada conjunto de diez Consejos Extraordinarios. \\
 				En el caso de los delegados de postgrado, las ausencias a aquellos consejos extraordinarios para decidir alguna votación ponderada de la FEUC no será considerada.
 
+				\item \label{extension_ausencias}
+				Será posible extender la cantidad de inasistencias justificadas posibles para un delegado en la cantidad que el Consejo estime adecuado, siempre teniendo presente el contexto y los motivos. Esto se podrá hacer a petición del delegado después de haber perdido el derecho a voz y voto en el Consejo correspondiente (en el que perdió voz y voto). El Consejo correspondiente podrá rechazar la solicitud en caso de que no la considere adecuada. Esto se podrá hacer solamente una vez por delegado durante su período.
+
 			\end{enumerate}
 
 			El tiempo mínimo que debe estar un miembro del Consejo durante una sesión para que su asistencia sea considerada es de 30 minutos. La asistencia de los miembros del Consejo debe ser publicada en la página web del CAi.\\


### PR DESCRIPTION
La actualización de la especificación de pérdida de voto se aprueba con 100% en ambos consejos.

La extensión de ausencias por motivos especiales se aprueba con 80% en el consejo generacional y con 100% en el académico.