### PR TITLE
definicion de proyectos formal

### DIFF
--- a/Estatutos CAi.tex
+++ b/Estatutos CAi.tex
@@ -987,6 +987,28 @@
 				\end{enumerate}
 			\end{art}
 
+		\subsection*{Sobre los proyectos}
+
+			\begin{art}
+				Para que una agrupación de estudiantes sea considerada para ser un proyecto asociado al Centro de Alumnos de Ingeniería debe explicitar mediante un documento presentado al CAi lo siguiente:
+
+				\begin{enumerate}
+					\item Actividades dirigidas a ingeniería que lo definen. Esto se debe complementar con una misión como proyecto.
+					\item Rol social que cumple junto con su aporte a la comunidad de ingeniería y/o exteriores.
+					\item Encargado(s) o coordinador(es) de proyecto, de los cuales al menos uno debe ser alumno regular de la Escuela de Ingeniería. Ninguno de ellos puede tener faltas a la ética mayores, tales y como están sea determinado por la Dirección de Pregrado de Ingeniería (DiPre).
+				\end{enumerate}
+
+			\end{art}
+
+			\begin{art}
+				Las especificaciones del proyecto deberán ser entregadas una vez al año al Centro de Alumnos de Ingeniería durante el mes de marzo, a más tardar una semana antes del último día hábil del mes, incluso para proyectos ya asociados al CAi.
+			\end{art}
+
+			\begin{art}
+				Las especificaciones deberán ser revisadas por un miembro del Comité Ejecutivo y un delegado de cada consejo y aprobadas o rechazadas en un plazo de cinco días hábiles después de que se hayan entregado las especificaciones. En caso de que estas sean rechazadas, se le dará al proyecto un plazo de 2 días hábiles para entregar un nuevo documento, el cual deberá ser revisado en los próximos 3 días hábiles. En caso de que se rechace de nuevo las especificaciones, la agrupación de personas no será considerada como un proyecto del Centro de Alumnos de Ingeniería, por lo que no podrá participar en los presupuestos participativos. El fin de esta verificación es tener catalogados los proyectos asociados al CAi con un formato completo y consistente, y no pretende otorgar al CAi soberanía sobre los proyectos.
+			\end{art}
+		
+
 		\subsection*{Sobre el Presupuesto Participativo}
 
 			\begin{art}\label{definicionPParticipativo1}


### PR DESCRIPTION
Actualmente no existe una definición formal de qué es un proyecto del Centro de Alumnos de Ingeniería, por lo que establecer qué es y como operan permitir ́a facilitar el funcionamiento del CAi con ellos, además de facilitar el procedimiento para los fondos concursables.

Para este semestre se refinó la redacción de los casos de faltas a la ética y que no se pretende otorgar al CAi soberanía sobre los proyectos.

La definición formal de los proyectos CAi se aprueba con 100% en ambos consejos.