### PR TITLE
Requisitos y permanencia

### DIFF
--- a/Estatutos CAi.tex
+++ b/Estatutos CAi.tex
@@ -295,7 +295,6 @@
 				\item Presidir el Consejo Académico.
 				\item Representar a los alumnos ante el \emph{CIDEI}, el Consejo de la Escuela de Ingeniería y el Comité de Pregrado, en conjunto con el Presidente de CAi.
 				\item Estudiar y desarrollar proyectos y propuestas académicas con la Dirección de la Escuela y, si existiese, la Comisión de Docencia del CAi, preocupándose también de su difusión.
-				\item Preparar y ejecutar las defensas de los alumnos respecto de las causales de eliminación, frente a la Comisión de la Escuela.
 				\item Asistir a las instancias formales para las que sea llamado junto a sus pares de las demás facultades por el Consejero Superior FEUC, tales como el Consejo Académico FEUC.
 				\item Dar cuenta pública, en las sesiones ordinarias del Consejo Generacional y Académico, de su participación en el Consejo Académico FEUC y en las instancias en las que participa regularmente como representante de los alumnos ante las autoridades de la Escuela.
 			\end{enumerate}
@@ -560,19 +559,21 @@
 					\begin{enumerate}
 						\item Tener a lo menos tres semestres cursados en la unidad académica o 150 créditos aprobados de algún currículum de Ingeniería Civil al momento de la elección.
 						
-						\item Tener un promedio ponderado de los últimos tres Promedio Semestral de notas (PPS), al momento de la elección, superior o igual a 4,50.
+						\item No haber caído en Comisión de Permanencia y que no se pueda caer en Comisión de Permanencia al momento de inscribir la candidatura.
 
-						Esta norma tiene por objetivo que ningún miembro del Comité Ejecutivo caiga en causal de eliminación durante su ejercicio. El organismo oficial de validación es la Dirección de Pregrado de la Escuela de Ingeniería.
+						Esta norma tiene por objetivo que ningún miembro del Comité Ejecutivo caiga en Comisión de Permanencia durante su ejercicio. El organismo oficial de validación es la Dirección de Pregrado de la Escuela de Ingeniería.
 					\end{enumerate}
 				\item En el caso de alumnos de postgrado:
 					\begin{enumerate}
 						\item En el caso de alumnos en primer semestre del programa, cumplir con los requisitos establecidos para alumnos de pregrado.
 						\item En el caso de alumnos de segundo semestre en adelante, contar con un PPA superior o igual a 5,00.
 
-						Esta norma tiene por objetivo que ningún miembro del Comité Ejecutivo caiga en causal de eliminación durante su ejercicio. El organismo oficial de validación es la Dirección de Postgrado de la Escuela de Ingeniería.
+						Esta norma tiene por objetivo que ningún miembro del Comité Ejecutivo caiga en Comisión de Permanencia durante su ejercicio. El organismo oficial de validación es la Dirección de Postgrado de la Escuela de Ingeniería.
 					\end{enumerate}
 
-				\item No haber caído en causal de eliminación durante el año previo al de la elección.
+					\item No haber caído en Comisión de Permanencia durante el año previo al de la elección.
+	
+					\item No haber acumulado dos o más alertas académicas.
 				
 				\item Tener antecedentes de probidad académica intachables. 
 
@@ -581,7 +582,7 @@
 		\end{art}
 
 		\begin{art}\label{requisitosPresidente}
-			El candidato a Presidente del CAi deberá tener un promedio ponderado acumulado de notas (PPA) superior o igual 4,80 y a lo menos 200 créditos aprobados de algún programa de la Escuela de Ingeniería Civil al momento de la preinscripción.
+			El candidato a Presidente del CAi deberá tener a lo menos 200 créditos aprobados de algún programa de la Escuela de Ingeniería Civil al momento de la preinscripción.
 		\end{art}
 
 		\begin{art}\label{requisitosJefeInvestigacion}
@@ -591,9 +592,10 @@
 		\begin{art}\label{requisitosCAPregrado}
 			Los candidatos a Consejero Académico deberán cumplir con los siguientes requisitos, al momento de la preinscripción:
 			\begin{enumerate}
-				\item Ser alumno regular de algún major o título profesional de Ingeniería Civil con PPA superior 4.80.
+				\item Ser alumno regular de algún major o título profesional de Ingeniería Civil.
 				\item Haber aprobado al menos 200 créditos al momento de inscribir la candidatura.
-				\item No haber caído en causal de eliminación.
+				\item No haber caído en Comisión de Permanencia o haber acumulado dos o más alertas académicas.
+				\item No poder caer en Comisión de Permanencia al momento de inscribir la candidatura.
 				\item Tener antecedentes de probidad académica intachables. 
 
 
@@ -606,7 +608,7 @@
 			\begin{enumerate}
 				\item Ser alumno regular o en vías de grado de Postgrado con PPA superior 5.00.
 				\item Haber completado al menos un semestre en algún programa de Postgrado de la Escuela de Ingeniería.
-				\item No haber caído en causal de eliminación.
+				\item No haber caído en Comisión de Permanencia o haber acumulado dos o más alertas académicas.
 				\item Tener antecedentes de probidad académica intachables. 
 
 				El TRICEL será responsable de velar por todos los incisos de este artículo.
@@ -700,7 +702,7 @@
 						\item La aprobación de cada Consejo, la cual se obtendrá mediante la aprobación de dos tercios de los votos posibles, si se tratase de un miembro del Comité Ejecutivo, del Consejero Académico, o del Consejero de Postgrado.
 						\item La aprobación de dos tercios de los votos posibles del Consejo al que pertenezca excluyéndose al afectado, en caso de tratarse de algún delegado o del Representante de College.
 					\end{itemize}
-				\item\label{causal} Caer en causal de eliminación.
+				\item\label{permanencia} Caer en Comisión de Permanencia.
 				\item Involucrarse en situaciones de probidad académica reprochables. El Consejo al que pertenezca será responsable de velar por esto.
 				\item Asumir otro cargo de representación que integre el Consejo Generacional o Académico del CAi.
 				\item Ejercer alguno de los cargos de representación enunciados a continuación:

--- a/Estatutos CAi.tex
+++ b/Estatutos CAi.tex
@@ -559,11 +559,13 @@
 					\begin{enumerate}
 						\item Tener a lo menos tres semestres cursados en la unidad académica o 150 créditos aprobados de algún currículum de Ingeniería Civil al momento de la elección.
 						
-						\item No haber caído en Comisión de Permanencia y que no se pueda caer en Comisión de Permanencia al momento de inscribir la candidatura.
+						\item Tener un promedio ponderado de los últimos tres Promedio Semestral de notas (PPS), al momento de la elección, superior o igual a 4,50.
 
 						Esta norma tiene por objetivo que ningún miembro del Comité Ejecutivo caiga en Comisión de Permanencia durante su ejercicio. El organismo oficial de validación es la Dirección de Pregrado de la Escuela de Ingeniería.
 					\end{enumerate}
 				\item En el caso de alumnos de postgrado:
+
+				\item 
 					\begin{enumerate}
 						\item En el caso de alumnos en primer semestre del programa, cumplir con los requisitos establecidos para alumnos de pregrado.
 						\item En el caso de alumnos de segundo semestre en adelante, contar con un PPA superior o igual a 5,00.
@@ -571,9 +573,9 @@
 						Esta norma tiene por objetivo que ningún miembro del Comité Ejecutivo caiga en Comisión de Permanencia durante su ejercicio. El organismo oficial de validación es la Dirección de Postgrado de la Escuela de Ingeniería.
 					\end{enumerate}
 
-					\item No haber caído en Comisión de Permanencia durante el año previo al de la elección.
-	
-					\item No haber acumulado dos o más alertas académicas.
+				\item No haber caído en Comisión de Permanencia durante los últimos dos semestres efectivamente cursados.
+
+				\item No haber acumulado dos o más alertas académicas en los últimos 3 semestres efectivamente cursados.
 				
 				\item Tener antecedentes de probidad académica intachables. 
 
@@ -582,7 +584,7 @@
 		\end{art}
 
 		\begin{art}\label{requisitosPresidente}
-			El candidato a Presidente del CAi deberá tener a lo menos 200 créditos aprobados de algún programa de la Escuela de Ingeniería Civil al momento de la preinscripción.
+			El candidato a Presidente del CAi deberá tener un promedio ponderado acumulado de notas (PPA) superior o igual 4,80 y a lo menos 200 créditos aprobados de algún programa de la Escuela de Ingeniería Civil al momento de la preinscripción.
 		\end{art}
 
 		\begin{art}\label{requisitosJefeInvestigacion}
@@ -592,13 +594,13 @@
 		\begin{art}\label{requisitosCAPregrado}
 			Los candidatos a Consejero Académico deberán cumplir con los siguientes requisitos, al momento de la preinscripción:
 			\begin{enumerate}
-				\item Ser alumno regular de algún major o título profesional de Ingeniería Civil.
+				\item Ser alumno regular de algún major o título profesional de Ingeniería Civil con PPA superior 4.80.
+		
 				\item Haber aprobado al menos 200 créditos al momento de inscribir la candidatura.
-				\item No haber caído en Comisión de Permanencia o haber acumulado dos o más alertas académicas.
-				\item No poder caer en Comisión de Permanencia al momento de inscribir la candidatura.
+		
+				\item No haber caído en Comisión de Permanencia o haber acumulado dos o más alertas académicas en los últimos dos semestres efectivamente cursados.
+		
 				\item Tener antecedentes de probidad académica intachables. 
-
-
 				El TRICEL será responsable de velar por todos los incisos de este artículo.
 			\end{enumerate}
 		\end{art}
@@ -607,8 +609,11 @@
 			Los candidatos al cargo de Consejero de Postgrado deberán cumplir con los siguientes requisitos, al momento de la preinscripción:
 			\begin{enumerate}
 				\item Ser alumno regular o en vías de grado de Postgrado con PPA superior 5.00.
+
 				\item Haber completado al menos un semestre en algún programa de Postgrado de la Escuela de Ingeniería.
-				\item No haber caído en Comisión de Permanencia o haber acumulado dos o más alertas académicas.
+
+				\item No haber caído en causal de eliminación.
+
 				\item Tener antecedentes de probidad académica intachables. 
 
 				El TRICEL será responsable de velar por todos los incisos de este artículo.


### PR DESCRIPTION
Se aprueba sujeto a los últimos cambios realizados al archivo en ambos consejos.

Se mantiene el PPS para lista CAi.
Se mantiene PPA para presidente y consejería académica.
Se reemplaza Causal de eliminación por Comisión de Permanencia.
Se pide que no se haya caído en Comisión de Permanencia y no se haya tenido alertas en los últimos semestres efectivamente cursados especificados.