### PR TITLE
reducción de cantidad de cambios requeridos

### DIFF
--- a/Estatutos CAi.tex
+++ b/Estatutos CAi.tex
@@ -854,7 +854,7 @@
 							\item Difusión de información dentro del Consejo Generacional.
 						\end{enumerate}
 					
-					\item En la primera sesión ordinaria del Consejo Generacional se definirá la comisión de Fiscalización y Estatutos. Dicha comisión presentarán una cuenta pública 3 veces al año (una vez durante el primer semestre y dos veces durante el segundo). Deberá tener, por lo menos, cinco delegados generacionales y un miembro del CAi. También podrán sumarse delegados académicos a esta comisión. La comisión será liderada por dos miembros de esta.
+					\item En la primera sesión ordinaria del Consejo Generacional se definirá la comisión de Fiscalización y Estatutos. Dicha comisión presentarán una cuenta pública dos a tres veces durante el año (teniendo como mínimo una cada semestre). Deberá tener, por lo menos, cinco delegados generacionales y un miembro del CAi. También podrán sumarse delegados académicos a esta comisión. La comisión será liderada por dos miembros de esta.
 				\end{enumerate}
 			\end{art}
 


### PR DESCRIPTION
Actualmente los estatutos requieren que se cite dos veces a un Consejo de cambio de estatutos necesariamente. Esto no siempre tiene sentido, debido a que puede haber ocasiones en que no se requiera necesariamente llevar mas cambios, por lo que se pretende dejar la libertad de hacerlo entre una y dos veces el segundo semestre, manteniendo como mínimo una vez en cada semestre.