### PR TITLE
Modificación Art4. a lenguaje neutro

### DIFF
--- a/estatutos.tex
+++ b/estatutos.tex
@@ -151,32 +151,32 @@
 \begin{art}\label{organismosCAi}
 	Los organismos directivos del CAi son los siguientes:
 	\begin{enumerate}
-		\item \label{jerarquia} \textsc{Comité Ejecutivo} Encabeza al CAi. Está formado por ocho miembros. En orden jerárquico, este está formado por:
+		\item \label{jerarquia} \textsc{Comité Ejecutivo} Encabeza al CAi. Está formado por ocho integrantes. En orden jerárquico, este está formado por:
 		      \begin{enumerate}
-			      \item Presidente.
-			      \item Primer Vicepresidente.
-			      \item Segundo Vicepresidente.
-			      \item Secretario General.
-			      \item Jefe de Finanzas.
-			      \item Coordinador de Áreas.
-			      \item Jefe de Docencia
-			      \item Jefe de Investigación
+			      \item Presidencia.
+			      \item Primera Vicepresidencia.
+			      \item Segunda Vicepresidencia.
+			      \item Secretaría General.
+			      \item Jefatura de Finanzas.
+			      \item Coordinación de Áreas.
+			      \item Jefatura de Docencia.
+			      \item Jefatura de Investigación.
 		      \end{enumerate}
-		      El Presidente podrá ampliar el número y las funciones y atribuciones de los miembros del Comité Ejecutivo dentro de sus propias facultades.
+		      La Presidencia podrá ampliar el número y las funciones y atribuciones de los integrantes del Comité Ejecutivo dentro de sus propias facultades.
 
-		\item \textsc{Consejería Académica de Pregrado, conformada por}:
+		\item \textsc{Consejería Académica de Pregrado, conformada por dos integrantes}:
 		      \begin{enumerate}
-			      \item Consejero Académico de Pregrado, en adelante Consejero Académico
-			      \item Subconsejero Académico de Pregrado, en adelante Subconsejero Académico
-		      \end{enumerate}
-
-		\item \textsc{Consejería Académica de Postgrado, conformada por}:
-		      \begin{enumerate}
-			      \item Consejero Académico de Postgrado, en adelante Consejero de Postgrado
-			      \item Subconsejero Académico de Postgrado, en adelante Subconsejero de Postgrado
+			      \item Consejería Académica de Pregrado, en adelante Consejería Académica
+			      \item Subconsejería Académica de Pregrado, en adelante Subconsejería Académica
 		      \end{enumerate}
 
-		\item \textsc{Comité Generacional} Está formado por tres representantes de cada generación, cuyo año de ingreso sea menor al de la quinta generación y tres representantes de la sexta o superior. Los anteriores serán nombrados en adelante como Delegados Generacionales.
+		\item \textsc{Consejería Académica de Postgrado, conformada por dos integrantes}:
+		      \begin{enumerate}
+			      \item Consejería Académica de Postgrado, en adelante Consejería de Postgrado
+			      \item Subconsejería Académica de Postgrado, en adelante Subconsejería de Postgrado
+		      \end{enumerate}
+
+		\item \textsc{Comité Generacional} Está formado por tres representantes de cada generación, cuyo año de ingreso sea menor al de la quinta generación y tres representantes de la sexta o superior, quienes se nombran en adelante como Representantes Generacionales.
 
 		\item \textsc{Comité Académico} Está formado por un representante de cada major, que debe estar inscrito en el major respectivo y que debe estar cursando al menos la tercera generación; por un representante de cada departamento, centro o especialidad, que debe estar cursando una mención en ese departamento o realizando dicha especialidad, con un máximo de un representante por departamento o centro; por 7 representantes de postgrado (3 votos), de cada una de las áreas del programa; y un Representante de College. Las áreas son las siguientes:
 		      \begin{enumerate}
@@ -188,9 +188,9 @@
 			      \item Química y Bioprocesos e Instituto de Ingeniería Biológica y Médica)
 		      \end{enumerate}
 
-		\item \textsc{Consejo Generacional} Es la máxima instancia de representación. Formado por el Comité Generacional, el Comité Ejecutivo, el Consejero Académico y el Consejero de Postgrado. Es presidido por el Presidente del CAi.
+		\item \textsc{Consejo Generacional} Es la máxima instancia de representación. Formado por el Comité Generacional, el Comité Ejecutivo, la Consejería Académica y la Consejería de Postgrado. Es presidido por la Presidencia del CAi.
 
-		\item \textsc{Consejo Académico} Formado por el Comité Académico, el jefe de Docencia y el Jefe de Investigación del Comité ejecutivo, y los miembros de las Consejerías Académicas de Postgrado y Pregrado, quien lo preside.
+		\item \textsc{Consejo Académico} Formado por el Comité Académico, la Jefatura de Docencia y la Jefatura de Investigación del Comité ejecutivo, y las Consejerías Académicas de Postgrado y Pregrado, quien lo preside.
 
 		\item \textsc{Comisiones} Las comisiones dependen del Comité Ejecutivo y lo ayudan en su gestión. El Comité Ejecutivo puede formar las comisiones que estime conveniente durante el período de su gestión, informando de ello a los Consejos. A modo de referencia, una lista sugerida de las posibles comisiones es la siguiente:
 		      \begin{enumerate}
@@ -201,7 +201,7 @@
 			      \item Deportes
 			      \item Docencia
 			      \item Emprendimiento
-			      \item Novatos
+			      \item Generación Novata
 			      \item Política y Actualidad
 			      \item Proyectos
 			      \item Responsabilidad Social
@@ -209,7 +209,7 @@
 			      \item Vida Universitaria
 		      \end{enumerate}
 
-		\item \textsc{Coordinadores Generales} Alumno regular de la Escuela de Ingeniería que es designado por el Comité Ejecutivo para apoyar o liderar algún área de trabajo del CAi. La designación de uno o más Coordinadores Generales debe ser informado al Consejo Generacional, al igual que eventuales reemplazos o renuncias. No es miembro del Comité Ejecutivo.
+		\item \textsc{Coordinación Generales} Alumno regular de la Escuela de Ingeniería que es designado por el Comité Ejecutivo para apoyar o liderar algún área de trabajo del CAi. La designación de uno o más Coordinaciones Generales debe ser informado al Consejo Generacional, al igual que eventuales reemplazos o renuncias. No es integrante del Comité Ejecutivo.
 	\end{enumerate}
 \end{art}
 


### PR DESCRIPTION
Se modifican el nombres de los cargos del comité ejecutivo del CAi y de ambas consejerías a un lenguaje neutro, y se modifica la redacción del articulo hacia un lenguaje neutro. Aprobado por ambos consejos en 2021-2