### PR TITLE
Modificación Art4.E correción cantidad representantes de postgrado

### DIFF
--- a/estatutos.tex
+++ b/estatutos.tex
@@ -178,7 +178,7 @@
 
 		\item \textsc{Comité Generacional} Está formado por tres representantes de cada generación, cuyo año de ingreso sea menor al de la quinta generación y tres representantes de la sexta o superior, quienes se nombran en adelante como Representantes Generacionales.
 
-		\item \textsc{Comité Académico} Está formado por un representante de cada major, que debe estar inscrito en el major respectivo y que debe estar cursando al menos la tercera generación; por un representante de cada departamento, centro o especialidad, que debe estar cursando una mención en ese departamento o realizando dicha especialidad, con un máximo de un representante por departamento o centro; por 7 representantes de postgrado (3 votos), de cada una de las áreas del programa; y un Representante de College. Las áreas son las siguientes:
+		\item \textsc{Comité Académico} Está formado por una persona representante de cada major, que debe haber inscrito el major respectivo y que debe estar cursando al menos la tercera generación; por un representante de cada departamento, centro o especialidad, que debe estar cursando una mención en ese departamento o realizando dicha especialidad, con un máximo de una representante por departamento o centro; por 6 representantes de postgrado, de cada una de las áreas del programa; y una Representante de College. Las áreas son las siguientes:
 		      \begin{enumerate}
 			      \item Ingeniería Civil (Gestión de la Construcción, Estructural y Geotecnia, Hidráulica y Ambiental
 			      \item Industrial y de Transporte e Instituto de Matemática


### PR DESCRIPTION
Correción cantidad representantes de postgrado indicaba que eran 7 y realmente eran 6,  y la cantidad de votos que tienen se elimina del articulo ya que pertenece a un articulo más adelante en el estatuto. Aprobado por ambos consejos en 2021-2