### PR TITLE
Modificación Art.31 13C desempate por azar

### DIFF
--- a/estatutos.tex
+++ b/estatutos.tex
@@ -678,7 +678,7 @@
 			            \\
 			            Tratándose del Representante de College será elegida la primera mayoría.
 			      \item En caso de no llenarse los cupos para los distintos cargos, se perderá la representación correspondiente a los cargos no ocupados.
-			      \item En caso de empate saldrá elegido el de mayor prioridad académica y en el caso de los novatos, el que haya entrado con mayor puntaje.
+			      \item En caso de empate, será elegida de manera aleatoria, según el mecanismo libre de sesgo que el TRICEL determine, con las personas implicadas presentes, y con un máximo de dos días hábiles para realizar el sorteo e informar a ambos consejos del resultado.
 		      \end{enumerate}
 	\end{enumerate}
 \end{art}
@@ -1232,6 +1232,10 @@
 	\textsc{Estatutos modificados por el Consejo Generacional y el Consejo Académico 2021}\\
 	Florencia Calvo Carvacho, Presidente CAi UC 2021\\
 	Fernando Torres Irarrázabal, Consejero Académico CAi UC 2021\\
+
+	\textsc{Estatutos modificados por el Consejo Generacional y el Consejo Académico 2022}\\
+	Karina Alarcón von Loebenstein, Presidente CAi UC 2022\\
+	Ria Deane Takahashi, Consejera Académica CAi UC 2022\\
 
 \end{sloppypar}
 \end{document}


### PR DESCRIPTION
Se modifica el Art.31 inciso 13C para que, en caso de empate entre candidaturas, se elegirá mediante un sorteo al azar libre de sesgo y con las personas implicadas presentes.