### PR TITLE
fix: escapar shortcode de ejemplo en comentario

### DIFF
--- a/anexos/oficios-interpretativos.qmd
+++ b/anexos/oficios-interpretativos.qmd
@@ -61,7 +61,7 @@ Los Oficios Interpretativos son emitidos por el Comité Ejecutivo conforme al **
 
   2. AGREGAR EL INCLUDE EN ESTE ARCHIVO
      Insertar en orden cronológico:
-     {{< include oficios/_oi-[año]-[n].qmd >}}
+     `{{< include oficios/_oi-[año]-[n].qmd >}}`
 
   3. AGREGAR EL ENLACE AL PDF ORIGINAL
      En el bloque other-links del frontmatter de este archivo,


### PR DESCRIPTION
## Problema

El archivo `anexos/oficios-interpretativos.qmd` tiene un bloque de instrucciones dentro de un comentario HTML (`<!-- -->`), pero incluía la línea:

```
{{< include oficios/_oi-[año]-[n].qmd >}}
```

Quarto procesa shortcodes `{{< >}}` **antes** de ignorar los comentarios HTML, por lo que intentaba incluir literalmente el archivo `_oi-[año]-[n].qmd`, que no existe.

## Solución

Envolver el shortcode de ejemplo en backticks para que Quarto lo trate como texto literal y no lo procese.